### PR TITLE
support verilog parser with input/output in name

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -271,7 +271,7 @@ std::map<std::string, std::shared_ptr<Port>> get_port_from_mod_def(Generator *ge
                                                                    const std::string &mod_def) {
     std::map<std::string, std::shared_ptr<Port>> result;
     std::unordered_set<std::string> ignore_list = {"logic", "reg", "wire"};
-    std::regex re("(input|output)\\s?([\\w,\\s_$\\[\\]:])+", std::regex::ECMAScript);  // NOLINT
+    std::regex re("(input|output)(\\s|\\[)\\s?([\\w,\\s_$\\[\\]:])+", std::regex::ECMAScript);  // NOLINT
     std::smatch match;
     std::string::const_iterator iter = mod_def.cbegin();
     while (std::regex_search(iter, mod_def.end(), match, re)) {

--- a/tests/test_generator.cc
+++ b/tests/test_generator.cc
@@ -26,6 +26,9 @@ TEST(generator, load) {  // NOLINT
     EXPECT_EQ(mod.get_port("a")->port_type(), PortType::Clock);
     ASSERT_ANY_THROW(
         Generator::from_verilog(&c, "module1.sv", "module1", {}, {{"aa", PortType::Clock}}));
+    mod = (Generator::from_verilog(&c, "module1.sv", "module4", {}, {}));
+    EXPECT_TRUE(mod.get_port("input_port") != nullptr);
+    EXPECT_TRUE(mod.get_port("output_port") != nullptr);
 }
 
 TEST(generator, port) {  // NOLINT

--- a/tests/vectors/module1.sv
+++ b/tests/vectors/module1.sv
@@ -15,3 +15,9 @@ module module3(a, b, c, f);
     input a, b, c;
 // Description goes here
 endmodule
+
+module module4(input_port, output_port);
+    input input_port;
+    output output_port;
+// Description goes here
+endmodule


### PR DESCRIPTION
Previously if port has `input` or `output` in its name, it failed parsing.
Improve regex to support these port names.